### PR TITLE
Add Helm chart

### DIFF
--- a/.github/workflows/helm-lint-test.yaml
+++ b/.github/workflows/helm-lint-test.yaml
@@ -1,0 +1,59 @@
+name: Lint and test Helm chart
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.7.2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.2.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --config deployment/ct.yaml)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Run chart-testing (lint)
+        run: ct lint --config deployment/ct.yaml
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.2.0
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - uses: azure/setup-kubectl@v2.0
+        id: install
+      - name: Setup OpenShift dependencies
+        run: |
+          kubectl apply -f deployment/hack/crds/*.yaml
+          kubectl wait --for condition="established" -f deployment/hack/crds/*.yaml
+          kubectl create ns console-plugin-nvidia-gpu
+          openssl req -x509 \
+            -newkey rsa:2048  \
+            -sha256 \
+            -new -nodes  \
+            -days 365 \
+            -keyout ca.key \
+            -out ca.crt \
+            -subj "/CN=example.com"
+          kubectl create -n console-plugin-nvidia-gpu secret tls plugin-serving-cert --key ca.key --cert ca.crt
+
+      - name: Run chart-testing (install)
+        run: ct install --namespace console-plugin-nvidia-gpu --config deployment/ct.yaml

--- a/.github/workflows/sync-readme.yaml
+++ b/.github/workflows/sync-readme.yaml
@@ -1,0 +1,26 @@
+name: Sync README.md of gh-pages branch with main branch
+
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "README.md"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          cp -f deployment/console-plugin-nvidia-gpu/README.md ${{ runner.temp }}/README.md
+      - uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+      - run: |
+          cp -f ${{ runner.temp }}/README.md .
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git add README.md
+          git commit --signoff -m "Sync deployment/console-plugin-nvidia-gpu/README.md from main"
+          git push

--- a/README.md
+++ b/README.md
@@ -1,18 +1,48 @@
-# OpenShift Console GPU Plugin
+# OpenShift Console NVIDIA GPU Plugin
 
-Dynamic plugin for OpenShift Container Platform console which adds GPU capabilities.
+Dynamic plugin for the OpenShift console which adds GPU capabilities.
 
-# Local development
-OpenShift Console Nvidia GPU Plugin works as a remote bundle for OCP console. To run OpenShift Console Nvidia GPU Plugin there should be a instance of OCP console up and running. Follow these steps to run OCP Console in development mode:
+## QuickStart
 
- - Follow everything as mentioned in the console [README.md](https://github.com/openshift/console) to build the application.
+### Prerequisites
+
+- [Red Hat OpenShift](https://www.redhat.com/en/technologies/cloud-computing/openshift) 4.10+
+- [NVIDIA GPU operator](https://github.com/NVIDIA/gpu-operator)
+- [Helm](https://helm.sh/docs/intro/install/)
+
+### Deployment
+
+```
+# add Helm repo
+$ helm repo add rh-ecosystem-edge https://rh-ecosystem-edge.github.io/console-plugin-nvidia-gpu
+$ helm repo update
+
+# install the Helm chart in the default NVIDIA GPU operator namespace
+$ helm install -n nvidia-gpu-operator console-plugin-nvidia-gpu rh-ecosystem-edge/console-plugin-nvidia-gpu
+
+# view deployed resources
+$ kubectl -n nvidia-gpu-operator get all -l app.kubernetes.io/name=console-plugin-nvidia-gpu
+
+# enable the plugin
+$ kubectl patch consoles.operator.openshift.io cluster --patch '{ "spec": { "plugins": ["console-plugin-nvidia-gpu"] } }' --type=merge
+```
+
+### Local development
+
+OpenShift Console NVIDIA GPU Plugin works as a remote bundle for OCP console. To run OpenShift
+Console NVIDIA GPU Plugin there should be a instance of the OCP console up and running. Follow these
+steps to run the OCP Console in development mode:
+
+ - Follow everything as mentioned in the console [README.md](https://github.com/openshift/console)
+   to build the application.
  - Run the console bridge as follows `./bin/bridge -plugins console-plugin-nvidia-gpu=http://127.0.0.1:9001/`
  - Run developemnt mode of console by going into `console/frontend` and running `yarn run dev`
 
-After the OCP console is set as required by ODF Console. Performs the following steps to make it run.
+After the OCP console is set as required by the ODF Console. Perform the following steps to make it
+run:
 
- - Install & setup Nvidia GPU Operator
- - Clone this repo.
- - Pull all required dependencies by running `yarn install`.
- - Run the development mode by running `yarn start`.
+ - Install & setup the NVIDIA GPU Operator
+ - Clone this repo
+ - Pull all required dependencies by running `yarn install`
+ - Run the development mode by running `yarn start`
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ helm install -n nvidia-gpu-operator console-plugin-nvidia-gpu rh-ecosystem-edg
 $ kubectl -n nvidia-gpu-operator get all -l app.kubernetes.io/name=console-plugin-nvidia-gpu
 
 # enable the plugin
-$ kubectl patch consoles.operator.openshift.io cluster --patch '{ "spec": { "plugins": ["console-plugin-nvidia-gpu"] } }' --type=merge
+$ kubectl patch consoles.operator.openshift.io cluster --patch '[{"op": "add", "path": "/spec/plugins/-", "value": "console-plugin-nvidia-gpu" }]' --type=json
 ```
 
 ### Local development

--- a/deployment/console-plugin-nvidia-gpu/.helmignore
+++ b/deployment/console-plugin-nvidia-gpu/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deployment/console-plugin-nvidia-gpu/Chart.yaml
+++ b/deployment/console-plugin-nvidia-gpu/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+appVersion: latest
+description: |
+  Red Hat OpenShift dynamic console plugin that leverages the NVIDIA GPU operator metrics and serves the respective console-extensions. Requires Red Hat OpenShift version 4.10+
+name: console-plugin-nvidia-gpu
+sources:
+  - https://github.com/rh-ecosystem-edge/console-plugin-nvidia-gpu
+home: https://github.com/rh-ecosystem-edge/console-plugin-nvidia-gpu
+keywords:
+  - openshift-console
+  - nvidia
+  - gpu
+type: application
+version: 0.1.0
+maintainers:
+  - name: mresvanis
+    email: mres@redhat.com

--- a/deployment/console-plugin-nvidia-gpu/README.md
+++ b/deployment/console-plugin-nvidia-gpu/README.md
@@ -27,7 +27,7 @@ $ helm install -n nvidia-gpu-operator console-plugin-nvidia-gpu rh-ecosystem-edg
 $ kubectl -n nvidia-gpu-operator get all -l app.kubernetes.io/name=console-plugin-nvidia-gpu
 
 # enable the plugin
-$ kubectl patch consoles.operator.openshift.io cluster --patch '{ "spec": { "plugins": ["console-plugin-nvidia-gpu"] } }' --type=merge
+$ kubectl patch consoles.operator.openshift.io cluster --patch '[{"op": "add", "path": "/spec/plugins/-", "value": "console-plugin-nvidia-gpu" }]' --type=json
 ```
 
 ### Helm Tests

--- a/deployment/console-plugin-nvidia-gpu/README.md
+++ b/deployment/console-plugin-nvidia-gpu/README.md
@@ -1,0 +1,44 @@
+# Console Plugin NVIDIA GPU Helm Chart
+
+Console Plugin NVIDIA GPU is a [dynamic plugin](https://github.com/openshift/console/blob/master/frontend/packages/console-dynamic-plugin-sdk/README.md)
+for the [Red Hat OpenShift](https://www.redhat.com/en/technologies/cloud-computing/openshift)
+[console UI](https://github.com/openshift/console). It leverages the metrics of the [NVIDIA GPU operator components](https://github.com/NVIDIA/gpu-operator)
+in order to serve the respective [console-extensions](https://github.com/openshift/console/blob/master/frontend/packages/console-dynamic-plugin-sdk/README.md#console-extensionsjson).
+
+## QuickStart
+
+### Prerequisites
+
+- [Red Hat OpenShift](https://www.redhat.com/en/technologies/cloud-computing/openshift) 4.10+
+- [NVIDIA GPU operator](https://github.com/NVIDIA/gpu-operator)
+- [Helm](https://helm.sh/docs/intro/install/)
+
+### Deployment
+
+```
+# add Helm repo
+$ helm repo add rh-ecosystem-edge https://rh-ecosystem-edge.github.io/console-plugin-nvidia-gpu
+$ helm repo update
+
+# install Helm chart in the default NVIDIA GPU operator namespace
+$ helm install -n nvidia-gpu-operator console-plugin-nvidia-gpu rh-ecosystem-edge/console-plugin-nvidia-gpu
+
+# view deployed resources
+$ kubectl -n nvidia-gpu-operator get all -l app.kubernetes.io/name=console-plugin-nvidia-gpu
+
+# enable the plugin
+$ kubectl patch consoles.operator.openshift.io cluster --patch '{ "spec": { "plugins": ["console-plugin-nvidia-gpu"] } }' --type=merge
+```
+
+### Helm Tests
+
+The Console Plugin NVIDIA GPU Helm chart includes tests to verify the the console plugin's
+deployment. To run the tests run the following commands:
+
+```
+# install Helm chart if you have not already done so
+$ helm install -n nvidia-gpu-operator console-plugin-nvidia-gpu rh-ecosystem-edge/console-plugin-nvidia-gpu
+
+# run the tests
+$ helm test console-plugin-nvidia-gpu --timeout 2m
+```

--- a/deployment/console-plugin-nvidia-gpu/templates/NOTES.txt
+++ b/deployment/console-plugin-nvidia-gpu/templates/NOTES.txt
@@ -4,4 +4,4 @@ $ kubectl -n {{ .Release.Namespace }} get all -l app.kubernetes.io/name=console-
 
 Enable the plugin by running the following command:
 
-$ kubectl patch consoles.operator.openshift.io cluster --patch '{ "spec": { "plugins": ["console-plugin-nvidia-gpu"] } }' --type=merge
+$ kubectl patch consoles.operator.openshift.io cluster --patch '[{"op": "add", "path": "/spec/plugins/-", "value": "console-plugin-nvidia-gpu" }]' --type=json

--- a/deployment/console-plugin-nvidia-gpu/templates/NOTES.txt
+++ b/deployment/console-plugin-nvidia-gpu/templates/NOTES.txt
@@ -1,0 +1,7 @@
+View the Console Plugin NVIDIA GPU deployed resources by running the following command:
+
+$ kubectl -n {{ .Release.Namespace }} get all -l app.kubernetes.io/name=console-plugin-nvidia-gpu
+
+Enable the plugin by running the following command:
+
+$ kubectl patch consoles.operator.openshift.io cluster --patch '{ "spec": { "plugins": ["console-plugin-nvidia-gpu"] } }' --type=merge

--- a/deployment/console-plugin-nvidia-gpu/templates/_helpers.tpl
+++ b/deployment/console-plugin-nvidia-gpu/templates/_helpers.tpl
@@ -1,0 +1,66 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "console-plugin-nvidia-gpu.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "console-plugin-nvidia-gpu.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "console-plugin-nvidia-gpu.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "console-plugin-nvidia-gpu.labels" -}}
+helm.sh/chart: {{ include "console-plugin-nvidia-gpu.chart" . }}
+{{ include "console-plugin-nvidia-gpu.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: {{ include "console-plugin-nvidia-gpu.name" . }}
+app.kubernetes.io/instance: {{ include "console-plugin-nvidia-gpu.name" . }}
+app.kubernetes.io/part-of: {{ include "console-plugin-nvidia-gpu.name" . }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "console-plugin-nvidia-gpu.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "console-plugin-nvidia-gpu.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "console-plugin-nvidia-gpu.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "console-plugin-nvidia-gpu.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deployment/console-plugin-nvidia-gpu/templates/consoleplugin.yaml
+++ b/deployment/console-plugin-nvidia-gpu/templates/consoleplugin.yaml
@@ -1,0 +1,13 @@
+apiVersion: console.openshift.io/v1alpha1
+kind: ConsolePlugin
+metadata:
+  name: {{ include "console-plugin-nvidia-gpu.fullname" . }}
+  labels:
+    {{- include "console-plugin-nvidia-gpu.labels" . | nindent 4 }}
+spec:
+  displayName: 'Console Plugin NVIDIA GPU Template'
+  service:
+    name: {{ include "console-plugin-nvidia-gpu.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+    port: 9443
+    basePath: '/'

--- a/deployment/console-plugin-nvidia-gpu/templates/deployment.yaml
+++ b/deployment/console-plugin-nvidia-gpu/templates/deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "console-plugin-nvidia-gpu.fullname" . }}
+  labels:
+    {{- include "console-plugin-nvidia-gpu.labels" . | nindent 4 }}
+    app.openshift.io/runtime-namespace: {{ include "console-plugin-nvidia-gpu.name" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "console-plugin-nvidia-gpu.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "console-plugin-nvidia-gpu.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: 9443
+          protocol: TCP
+        volumeMounts:
+        - name: plugin-serving-cert
+          readOnly: true
+          mountPath: /var/serving-cert
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+      - name: plugin-serving-cert
+        secret:
+          secretName: plugin-serving-cert
+          defaultMode: 420
+      - name: nginx-conf
+        configMap:
+          name: nginx-conf
+          defaultMode: 420
+      restartPolicy: Always
+      dnsPolicy: ClusterFirst
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%

--- a/deployment/console-plugin-nvidia-gpu/templates/service.yaml
+++ b/deployment/console-plugin-nvidia-gpu/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "console-plugin-nvidia-gpu.fullname" . }}
+  labels:
+    {{- include "console-plugin-nvidia-gpu.labels" . | nindent 4 }}
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: plugin-serving-cert
+spec:
+  ports:
+  - name: 9443-tcp
+    protocol: TCP
+    port: 9443
+    targetPort: 9443
+  selector:
+    {{- include "console-plugin-nvidia-gpu.selectorLabels" . | nindent 4 }}
+  type: ClusterIP
+  sessionAffinity: None

--- a/deployment/console-plugin-nvidia-gpu/templates/tests/test-plugin-service.yaml
+++ b/deployment/console-plugin-nvidia-gpu/templates/tests/test-plugin-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-service-test"
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: {{ .Release.Name }}-service-test
+      image: quay.io/cilium/alpine-curl:v1.4.0
+      imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+      args:
+        - -XGET
+        - --silent
+        - --fail
+        - --insecure
+        - https://{{ include "console-plugin-nvidia-gpu.fullname" . }}.{{ .Release.Namespace }}.svc:9443/plugin-manifest.json
+  restartPolicy: Never

--- a/deployment/console-plugin-nvidia-gpu/values.yaml
+++ b/deployment/console-plugin-nvidia-gpu/values.yaml
@@ -1,0 +1,29 @@
+replicaCount: 1
+
+image:
+  repository: quay.io/edge-infrastructure/console-plugin-gpu
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  # tag: ""
+imagePullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/deployment/ct.yaml
+++ b/deployment/ct.yaml
@@ -1,0 +1,5 @@
+# See https://github.com/helm/chart-testing#configuration
+remote: origin
+target-branch: main
+chart-dirs:
+  - deployment

--- a/deployment/hack/crds/consoleplugin.customresourcedefinition.yaml
+++ b/deployment/hack/crds/consoleplugin.customresourcedefinition.yaml
@@ -1,0 +1,163 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: consoleplugins.console.openshift.io
+spec:
+  conversion:
+    strategy: None
+  group: console.openshift.io
+  names:
+    kind: ConsolePlugin
+    listKind: ConsolePluginList
+    plural: consoleplugins
+    singular: consoleplugin
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: "ConsolePlugin is an extension for customizing OpenShift web
+          console by dynamically loading code from another service running on the
+          cluster. \n Compatibility level 4: No compatibility is provided, the API
+          can change at any point for any reason. These capabilities should not be
+          used by applications needing long term support."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ConsolePluginSpec is the desired plugin configuration.
+            properties:
+              displayName:
+                description: displayName is the display name of the plugin.
+                minLength: 1
+                type: string
+              proxy:
+                description: proxy is a list of proxies that describe various service
+                  type to which the plugin needs to connect to.
+                items:
+                  description: ConsolePluginProxy holds information on various service
+                    types to which console's backend will proxy the plugin's requests.
+                  properties:
+                    alias:
+                      description: "alias is a proxy name that identifies the plugin's
+                        proxy. An alias name should be unique per plugin. The console
+                        backend exposes following proxy endpoint: \n /api/proxy/plugin/<plugin-name>/<proxy-alias>/<request-path>?<optional-query-parameters>
+                        \n Request example path: \n /api/proxy/plugin/acm/search/pods?namespace=openshift-apiserver"
+                      maxLength: 128
+                      minLength: 1
+                      pattern: ^[A-Za-z0-9-_]+$
+                      type: string
+                    authorize:
+                      default: false
+                      description: "authorize indicates if the proxied request should
+                        contain the logged-in user's OpenShift access token in the
+                        \"Authorization\" request header. For example: \n Authorization:
+                        Bearer sha256~kV46hPnEYhCWFnB85r5NrprAxggzgb6GOeLbgcKNsH0
+                        \n By default the access token is not part of the proxied
+                        request."
+                      type: boolean
+                    caCertificate:
+                      description: caCertificate provides the cert authority certificate
+                        contents, in case the proxied Service is using custom service
+                        CA. By default, the service CA bundle provided by the service-ca
+                        operator is used.
+                      pattern: ^-----BEGIN CERTIFICATE-----([\s\S]*)-----END CERTIFICATE-----\s?$
+                      type: string
+                    service:
+                      description: 'service is an in-cluster Service that the plugin
+                        will connect to. The Service must use HTTPS. The console backend
+                        exposes an endpoint in order to proxy communication between
+                        the plugin and the Service. Note: service field is required
+                        for now, since currently only "Service" type is supported.'
+                      properties:
+                        name:
+                          description: name of Service that the plugin needs to connect
+                            to.
+                          maxLength: 128
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: namespace of Service that the plugin needs
+                            to connect to
+                          maxLength: 128
+                          minLength: 1
+                          type: string
+                        port:
+                          description: port on which the Service that the plugin needs
+                            to connect to is listening on.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                      required:
+                      - name
+                      - namespace
+                      - port
+                      type: object
+                    type:
+                      description: type is the type of the console plugin's proxy.
+                        Currently only "Service" is supported.
+                      pattern: ^(Service)$
+                      type: string
+                  required:
+                  - alias
+                  - type
+                  type: object
+                type: array
+              service:
+                description: service is a Kubernetes Service that exposes the plugin
+                  using a deployment with an HTTP server. The Service must use HTTPS
+                  and Service serving certificate. The console backend will proxy
+                  the plugins assets from the Service using the service CA bundle.
+                properties:
+                  basePath:
+                    default: /
+                    description: basePath is the path to the plugin's assets. The
+                      primary asset it the manifest file called `plugin-manifest.json`,
+                      which is a JSON document that contains metadata about the plugin
+                      and the extensions.
+                    minLength: 1
+                    pattern: ^/
+                    type: string
+                  name:
+                    description: name of Service that is serving the plugin assets.
+                    maxLength: 128
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: namespace of Service that is serving the plugin assets.
+                    maxLength: 128
+                    minLength: 1
+                    type: string
+                  port:
+                    description: port on which the Service that is serving the plugin
+                      is listening to.
+                    format: int32
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
+                required:
+                - basePath
+                - name
+                - namespace
+                - port
+                type: object
+            required:
+            - service
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true


### PR DESCRIPTION
This pull request adds the Console Plugin NVIDIA GPU Helm chart, along with the [Github actions](https://github.com/features/actions) to lint, test, package and release the former. 

Specifically, the following changes are included:

- add the Console Plugin NVIDIA GPU Helm chart, along with the respective Helm tests
- add the following Github actions and workflows:
  - lint and run Helm tests on pull request events
  - sync gh-pages branch `README.md` on main branch `deployment/console-plugin-nvidia-gpu/README.md` changes
- add `deployment/hack/` directory with supporting files to facilitate local, CI and Github workflows development
- add [chart-testing](https://github.com/helm/chart-testing) configuration (`ct.yaml`), used in the lint and test Github workflow

#### Helm chart repository hosting

The chart is to be hosted via [Github Pages](https://helm.sh/docs/topics/chart_repository/#github-pages-example) in the current repository on a branch named `gh-pages`, which would have to be manually created and initialized. Its initialization includes setting up this branch with only the Helm chart repository assets and removing all source code or any other files included in the `main` branch.

#### Useful resources

- https://helm.sh/
- https://helm.sh/docs/topics/chart_repository/#github-pages-example
- https://github.com/marketplace/actions/helm-chart-testing
- https://github.com/helm/chart-testing