### PR TITLE
Remove conditional kind cluster setup in CI since it should be setup every time

### DIFF
--- a/.github/workflows/helm-lint-test.yaml
+++ b/.github/workflows/helm-lint-test.yaml
@@ -23,20 +23,11 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.2.0
 
-      - name: Run chart-testing (list-changed)
-        id: list-changed
-        run: |
-          changed=$(ct list-changed --config deployment/ct.yaml)
-          if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
-          fi
-
       - name: Run chart-testing (lint)
         run: ct lint --config deployment/ct.yaml
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0
-        if: steps.list-changed.outputs.changed == 'true'
 
       - uses: azure/setup-kubectl@v2.0
         id: install


### PR DESCRIPTION
This PR removes the conditional setup of the [kind](https://kind.sigs.k8s.io/) cluster in the Helm lint CI job, since in order to test the Helm chart the cluster should be setup every time.