### PR TITLE
Fix Helm chart default image repository having the wrong name

### DIFF
--- a/deployment/console-plugin-nvidia-gpu/Chart.yaml
+++ b/deployment/console-plugin-nvidia-gpu/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
   - nvidia
   - gpu
 type: application
-version: 0.1.0
+version: 0.2.0
 maintainers:
   - name: mresvanis
     email: mres@redhat.com

--- a/deployment/console-plugin-nvidia-gpu/values.yaml
+++ b/deployment/console-plugin-nvidia-gpu/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: quay.io/edge-infrastructure/console-plugin-gpu
+  repository: quay.io/edge-infrastructure/console-plugin-nvidia-gpu
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   # tag: ""


### PR DESCRIPTION
This PR replaces the default image repository in the Helm chart values with the correct one, as the previous was pointing to a non-existent image repository.