### PR TITLE
Enhance deployment documentation to point to alternative patch instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,13 @@ $ helm install -n nvidia-gpu-operator console-plugin-nvidia-gpu rh-ecosystem-edg
 # view deployed resources
 $ kubectl -n nvidia-gpu-operator get all -l app.kubernetes.io/name=console-plugin-nvidia-gpu
 
-# enable the plugin
+# check if a plugins field is specified
+$ oc get consoles.operator.openshift.io cluster --output=jsonpath="{.spec.plugins}"
+
+# if not, then run the following to enable the plugin
+$ kubectl patch consoles.operator.openshift.io cluster --patch '{ "spec": { "plugins": ["console-plugin-nvidia-gpu"] } }' --type=merge
+
+# if yes, then run the following to enable the plugin
 $ kubectl patch consoles.operator.openshift.io cluster --patch '[{"op": "add", "path": "/spec/plugins/-", "value": "console-plugin-nvidia-gpu" }]' --type=json
 ```
 

--- a/deployment/console-plugin-nvidia-gpu/Chart.yaml
+++ b/deployment/console-plugin-nvidia-gpu/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
   - nvidia
   - gpu
 type: application
-version: 0.2.0
+version: 0.2.1
 maintainers:
   - name: mresvanis
     email: mres@redhat.com

--- a/deployment/console-plugin-nvidia-gpu/README.md
+++ b/deployment/console-plugin-nvidia-gpu/README.md
@@ -26,7 +26,13 @@ $ helm install -n nvidia-gpu-operator console-plugin-nvidia-gpu rh-ecosystem-edg
 # view deployed resources
 $ kubectl -n nvidia-gpu-operator get all -l app.kubernetes.io/name=console-plugin-nvidia-gpu
 
-# enable the plugin
+# check if a plugins field is specified
+$ oc get consoles.operator.openshift.io cluster --output=jsonpath="{.spec.plugins}"
+
+# if not, then run the following to enable the plugin
+$ kubectl patch consoles.operator.openshift.io cluster --patch '{ "spec": { "plugins": ["console-plugin-nvidia-gpu"] } }' --type=merge
+
+# if yes, then run the following to enable the plugin
 $ kubectl patch consoles.operator.openshift.io cluster --patch '[{"op": "add", "path": "/spec/plugins/-", "value": "console-plugin-nvidia-gpu" }]' --type=json
 ```
 

--- a/deployment/console-plugin-nvidia-gpu/templates/NOTES.txt
+++ b/deployment/console-plugin-nvidia-gpu/templates/NOTES.txt
@@ -2,6 +2,13 @@ View the Console Plugin NVIDIA GPU deployed resources by running the following c
 
 $ kubectl -n {{ .Release.Namespace }} get all -l app.kubernetes.io/name=console-plugin-nvidia-gpu
 
-Enable the plugin by running the following command:
+Enable the plugin by running the following commands:
 
+# check if a plugins field is specified
+$ oc get consoles.operator.openshift.io cluster --output=jsonpath="{.spec.plugins}"
+
+# if not, then run the following to enable the plugin
+$ kubectl patch consoles.operator.openshift.io cluster --patch '{ "spec": { "plugins": ["console-plugin-nvidia-gpu"] } }' --type=merge
+
+# if yes, then run the following to enable the plugin
 $ kubectl patch consoles.operator.openshift.io cluster --patch '[{"op": "add", "path": "/spec/plugins/-", "value": "console-plugin-nvidia-gpu" }]' --type=json


### PR DESCRIPTION
This PR enhances the Helm chart deployment documentation and instructions. Depending on the existence of the `Spec.Plugins` field of the cluster console CR, the `kubectl` patch command should be altered to allow for a valid request.