### PR TITLE
Address low and moderate security concerns

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,17 @@
 
-FROM registry.ci.openshift.org/open-cluster-management/builder:nodejs14-linux AS builder
+FROM registry.access.redhat.com/ubi8/nodejs-16:latest AS builder
+USER root
+RUN corepack enable yarn
+USER 1001
 
-ADD . /plugin
-WORKDIR /plugin
-RUN yarn install && yarn build
+COPY . /opt/app-root/src
+RUN yarn install --frozen-lockfile && yarn build
 
-FROM registry.access.redhat.com/ubi8/nginx-118
-ADD default.conf "${NGINX_CONFIGURATION_PATH}"
-COPY --from=builder /plugin/dist .
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+RUN microdnf install nginx \
+    && microdnf clean all \
+    && rm -rf /var/cache/yum
+COPY default.conf "${NGINX_CONFIGURATION_PATH}"
+COPY --from=builder /opt/app-root/src/dist .
+USER 1001
 CMD /usr/libexec/s2i/run

--- a/default.conf
+++ b/default.conf
@@ -2,6 +2,7 @@ server {
     listen       9443 ssl;
     ssl_certificate /var/serving-cert/tls.crt;
     ssl_certificate_key /var/serving-cert/tls.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
     location / {
         root   /opt/app-root/src;
     }


### PR DESCRIPTION
Use Red Hat UBI NodeJS 18 image as builder image in the Dockerfile.
This ensures that all images benefit from updates by Red Hat.

Add the USER statement to the Dockerfile to ensure a non root user
will run the application. Here 1001 is the default for UBI images.

Install NGINX on top of UBI 8 Minimal to reduce the image size and
possibly the attack surface. The size decreases from 452 MB to 216 MB.

Related to PLMPGM-829.

Signed-off-by: Fabien Dupont <fabiendupont@pm.me>