### PR TITLE
Revert to ubi8/nginx-120 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,8 @@ USER 1001
 COPY . /opt/app-root/src
 RUN yarn install --frozen-lockfile && yarn build
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
-RUN microdnf install nginx \
-    && microdnf clean all \
-    && rm -rf /var/cache/yum
-COPY default.conf "${NGINX_CONFIGURATION_PATH}"
+FROM registry.access.redhat.com/ubi8/nginx-120:latest
+COPY default.conf "NGINX_CONFIGURATION_PATH"
 COPY --from=builder /opt/app-root/src/dist .
 USER 1001
 CMD /usr/libexec/s2i/run


### PR DESCRIPTION
I've realized that the NGINX configuration deviates from default and
that it would require changing install paths for the content. It could
lead to more issues, so reverting to using ubi8/nginx-120 as base image.
The final image will be bigger, but it's safer for now.

Related to Related to PLMPGM-829.

Signed-off-by: Fabien Dupont <fabiendupont@pm.me>