### PR TITLE
Use ubi9/nginx-120:latest as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN corepack enable yarn
 COPY . /opt/app-root/src
 RUN yarn install --frozen-lockfile && yarn build
 
-FROM registry.access.redhat.com/ubi8/nginx-120:latest
+FROM registry.access.redhat.com/ubi9/nginx-120:latest
 COPY default.conf "${NGINX_CONFIGURATION_PATH}"
 COPY --from=builder /opt/app-root/src/dist .
 USER 1001


### PR DESCRIPTION
Provides updated python3-urllib3-1.26 fixing CVE-2021-33503.