### PR TITLE
Add DCGM exporter metrics ConfigMap to Helm Chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Dynamic plugin for the OpenShift console which adds GPU capabilities.
 
 ## OCP version compatibility
-| Nvidia GPU plugin      | OCP Console |
+| NVIDIA GPU plugin      | OCP Console |
 | ---------------------- | ----------- |
 | latest                 | 4.11+       |
 | release-0.0.1          | 4.10+       |
@@ -27,16 +27,19 @@ $ helm repo update
 $ helm install -n nvidia-gpu-operator console-plugin-nvidia-gpu rh-ecosystem-edge/console-plugin-nvidia-gpu
 
 # view deployed resources
-$ kubectl -n nvidia-gpu-operator get all -l app.kubernetes.io/name=console-plugin-nvidia-gpu
+$ oc -n nvidia-gpu-operator get all -l app.kubernetes.io/name=console-plugin-nvidia-gpu
 
 # check if a plugins field is specified
 $ oc get consoles.operator.openshift.io cluster --output=jsonpath="{.spec.plugins}"
 
 # if not, then run the following to enable the plugin
-$ kubectl patch consoles.operator.openshift.io cluster --patch '{ "spec": { "plugins": ["console-plugin-nvidia-gpu"] } }' --type=merge
+$ oc patch consoles.operator.openshift.io cluster --patch '{ "spec": { "plugins": ["console-plugin-nvidia-gpu"] } }' --type=merge
 
 # if yes, then run the following to enable the plugin
-$ kubectl patch consoles.operator.openshift.io cluster --patch '[{"op": "add", "path": "/spec/plugins/-", "value": "console-plugin-nvidia-gpu" }]' --type=json
+$ oc patch consoles.operator.openshift.io cluster --patch '[{"op": "add", "path": "/spec/plugins/-", "value": "console-plugin-nvidia-gpu" }]' --type=json
+
+# add the required DCGM Exporter metrics ConfigMap to the existing NVIDIA operator ClusterPolicy CR
+$ oc patch clusterpolicies.nvidia.com gpu-cluster-policy --patch '{ "spec": { "dcgmExporter": { "config": { "name": "console-plugin-nvidia-gpu" } } } }' --type=merge
 ```
 
 ### Local development

--- a/deployment/console-plugin-nvidia-gpu/Chart.yaml
+++ b/deployment/console-plugin-nvidia-gpu/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: latest
 description: |
-  Red Hat OpenShift dynamic console plugin that leverages the NVIDIA GPU operator metrics and serves the respective console-extensions. Requires Red Hat OpenShift version 4.10+
+  Red Hat OpenShift dynamic console plugin that leverages the NVIDIA GPU operator metrics and serves the respective console-extensions. Requires Red Hat OpenShift version 4.11+
 name: console-plugin-nvidia-gpu
 sources:
   - https://github.com/rh-ecosystem-edge/console-plugin-nvidia-gpu

--- a/deployment/console-plugin-nvidia-gpu/Chart.yaml
+++ b/deployment/console-plugin-nvidia-gpu/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
   - nvidia
   - gpu
 type: application
-version: 0.2.2
+version: 0.2.3
 maintainers:
   - name: mresvanis
     email: mres@redhat.com

--- a/deployment/console-plugin-nvidia-gpu/README.md
+++ b/deployment/console-plugin-nvidia-gpu/README.md
@@ -9,7 +9,7 @@ in order to serve the respective [console-extensions](https://github.com/openshi
 
 ### Prerequisites
 
-- [Red Hat OpenShift](https://www.redhat.com/en/technologies/cloud-computing/openshift) 4.10+
+- [Red Hat OpenShift](https://www.redhat.com/en/technologies/cloud-computing/openshift) 4.11+
 - [NVIDIA GPU operator](https://github.com/NVIDIA/gpu-operator)
 - [Helm](https://helm.sh/docs/intro/install/)
 

--- a/deployment/console-plugin-nvidia-gpu/README.md
+++ b/deployment/console-plugin-nvidia-gpu/README.md
@@ -30,10 +30,13 @@ $ kubectl -n nvidia-gpu-operator get all -l app.kubernetes.io/name=console-plugi
 $ oc get consoles.operator.openshift.io cluster --output=jsonpath="{.spec.plugins}"
 
 # if not, then run the following to enable the plugin
-$ kubectl patch consoles.operator.openshift.io cluster --patch '{ "spec": { "plugins": ["console-plugin-nvidia-gpu"] } }' --type=merge
+$ oc patch consoles.operator.openshift.io cluster --patch '{ "spec": { "plugins": ["console-plugin-nvidia-gpu"] } }' --type=merge
 
 # if yes, then run the following to enable the plugin
-$ kubectl patch consoles.operator.openshift.io cluster --patch '[{"op": "add", "path": "/spec/plugins/-", "value": "console-plugin-nvidia-gpu" }]' --type=json
+$ oc patch consoles.operator.openshift.io cluster --patch '[{"op": "add", "path": "/spec/plugins/-", "value": "console-plugin-nvidia-gpu" }]' --type=json
+
+# add the required DCGM Exporter metrics ConfigMap to the existing NVIDIA operator ClusterPolicy CR
+$ oc patch clusterpolicies.nvidia.com gpu-cluster-policy --patch '{ "spec": { "dcgmExporter": { "config": { "name": "console-plugin-nvidia-gpu" } } } }' --type=merge
 ```
 
 ### Helm Tests

--- a/deployment/console-plugin-nvidia-gpu/templates/NOTES.txt
+++ b/deployment/console-plugin-nvidia-gpu/templates/NOTES.txt
@@ -8,7 +8,10 @@ Enable the plugin by running the following commands:
 $ oc get consoles.operator.openshift.io cluster --output=jsonpath="{.spec.plugins}"
 
 # if not, then run the following to enable the plugin
-$ kubectl patch consoles.operator.openshift.io cluster --patch '{ "spec": { "plugins": ["console-plugin-nvidia-gpu"] } }' --type=merge
+$ oc patch consoles.operator.openshift.io cluster --patch '{ "spec": { "plugins": ["console-plugin-nvidia-gpu"] } }' --type=merge
 
 # if yes, then run the following to enable the plugin
-$ kubectl patch consoles.operator.openshift.io cluster --patch '[{"op": "add", "path": "/spec/plugins/-", "value": "console-plugin-nvidia-gpu" }]' --type=json
+$ oc patch consoles.operator.openshift.io cluster --patch '[{"op": "add", "path": "/spec/plugins/-", "value": "console-plugin-nvidia-gpu" }]' --type=json
+
+# add the required DCGM Exporter metrics ConfigMap to the existing NVIDIA operator ClusterPolicy CR
+$ oc patch clusterpolicies.nvidia.com gpu-cluster-policy --patch '{ "spec": { "dcgmExporter": { "config": { "name": "console-plugin-nvidia-gpu" } } } }' --type=merge

--- a/deployment/console-plugin-nvidia-gpu/templates/configmap.yaml
+++ b/deployment/console-plugin-nvidia-gpu/templates/configmap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "console-plugin-nvidia-gpu.fullname" . }}
+  labels:
+    {{- include "console-plugin-nvidia-gpu.labels" . | nindent 4 }}
+data:
+  dcgm-metrics.csv: |
+    DCGM_FI_PROF_GR_ENGINE_ACTIVE, gauge, gpu utilization.
+    DCGM_FI_DEV_MEM_COPY_UTIL, gauge, mem utilization.
+    DCGM_FI_DEV_ENC_UTIL, gauge, enc utilization.
+    DCGM_FI_DEV_DEC_UTIL, gauge, dec utilization.
+    DCGM_FI_DEV_POWER_USAGE, gauge, power usage.
+    DCGM_FI_DEV_POWER_MGMT_LIMIT_MAX, gauge, power mgmt limit.
+    DCGM_FI_DEV_GPU_TEMP, gauge, gpu temp.
+    DCGM_FI_DEV_SM_CLOCK, gauge, sm clock.
+    DCGM_FI_DEV_MAX_SM_CLOCK, gauge, max sm clock.
+    DCGM_FI_DEV_MEM_CLOCK, gauge, mem clock.
+    DCGM_FI_DEV_MAX_MEM_CLOCK, gauge, max mem clock.


### PR DESCRIPTION
This change adds the DCGM exporter metrics ConfigMap to the Helm Chart templates, in order to for it to be deployed alongside the Console Plugin. The metrics included are the required metrics for the NVIDIA GPU Admin Dashboard to be fully functional.

The name of this ConfigMap should be included in the NVIDIA operator ClusterPolicy CR, under `.spec.dcgmExporter.config.name`, for all the metrics to be exported as expected.

Signed-off-by: Michail Resvanis <mresvani@redhat.com>