### PR TITLE
Adjust the Helm Chart appVersion to point to the correct image tag

### DIFF
--- a/deployment/console-plugin-nvidia-gpu/Chart.yaml
+++ b/deployment/console-plugin-nvidia-gpu/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: latest
+appVersion: release-0.0.1
 description: |
   Red Hat OpenShift dynamic console plugin that leverages the NVIDIA GPU operator metrics and serves the respective console-extensions. Requires Red Hat OpenShift version 4.10+
 name: console-plugin-nvidia-gpu
@@ -11,7 +11,7 @@ keywords:
   - nvidia
   - gpu
 type: application
-version: 0.2.1
+version: 0.1.0
 maintainers:
   - name: mresvanis
     email: mres@redhat.com


### PR DESCRIPTION
This PR adjusts the Helm Chart `appVersion`, which is used as the console plugin's image tag, in order to make this version of the plugin available to users that would like to have the plugin on OCP 4.10.

https://github.com/rh-ecosystem-edge/console-plugin-nvidia-gpu/issues/42
 
Signed-off-by: Michail Resvanis <mresvani@redhat.com>