### PR TITLE
Noop commit with a patch to trigger image builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,3 @@ run:
  - Clone this repo
  - Pull all required dependencies by running `yarn install`
  - Run the development mode by running `yarn start`
-


### PR DESCRIPTION
The Prow cherrypicker plugin uses `git-am` to apply patches to a new branch that will be merged with the target branch of a Prow cherry-pick. If there is not patch, this command leads to a `Patch format detection failed.` error.

- https://github.com/abayer/test-infra/blob/v0.0.5/prow/external-plugins/cherrypicker/server.go#L369

Signed-off-by: Michail Resvanis <mresvani@redhat.com>