### PR TITLE
Fix API and parameterize port number

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 
 FROM registry.access.redhat.com/ubi8/nodejs-16:latest AS builder
 USER root
-RUN npm install -g corepack
-RUN corepack enable yarn
+RUN command -v yarn || npm i -g yarn
 
 COPY . /opt/app-root/src
 RUN yarn install --frozen-lockfile && yarn build

--- a/README.md
+++ b/README.md
@@ -5,14 +5,15 @@ Dynamic plugin for the OpenShift console which adds GPU capabilities.
 ## OCP version compatibility
 | NVIDIA GPU plugin      | OCP Console |
 | ---------------------- | ----------- |
-| latest                 | 4.11+       |
-| release-0.0.1          | 4.10+       |
+| latest                 | 4.12+       |
+| release-0.2.4          | 4.11        |
+| release-0.0.1          | 4.10        |
 
 ## QuickStart
 
 ### Prerequisites
 
-- [Red Hat OpenShift](https://www.redhat.com/en/technologies/cloud-computing/openshift) 4.11+
+- [Red Hat OpenShift](https://www.redhat.com/en/technologies/cloud-computing/openshift) 4.12+
 - [NVIDIA GPU operator](https://github.com/NVIDIA/gpu-operator)
 - [Helm](https://helm.sh/docs/intro/install/)
 

--- a/deployment/console-plugin-nvidia-gpu/Chart.yaml
+++ b/deployment/console-plugin-nvidia-gpu/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: latest
 description: |
-  Red Hat OpenShift dynamic console plugin that leverages the NVIDIA GPU operator metrics and serves the respective console-extensions. Requires Red Hat OpenShift version 4.11+
+  Red Hat OpenShift dynamic console plugin that leverages the NVIDIA GPU operator metrics and serves the respective console-extensions. Requires Red Hat OpenShift version 4.12+
 name: console-plugin-nvidia-gpu
 sources:
   - https://github.com/rh-ecosystem-edge/console-plugin-nvidia-gpu
@@ -11,7 +11,7 @@ keywords:
   - nvidia
   - gpu
 type: application
-version: 0.2.4
+version: 0.2.5
 maintainers:
   - name: mresvanis
     email: mres@redhat.com

--- a/deployment/console-plugin-nvidia-gpu/README.md
+++ b/deployment/console-plugin-nvidia-gpu/README.md
@@ -9,7 +9,7 @@ in order to serve the respective [console-extensions](https://github.com/openshi
 
 ### Prerequisites
 
-- [Red Hat OpenShift](https://www.redhat.com/en/technologies/cloud-computing/openshift) 4.11+
+- [Red Hat OpenShift](https://www.redhat.com/en/technologies/cloud-computing/openshift) 4.12+
 - [NVIDIA GPU operator](https://github.com/NVIDIA/gpu-operator)
 - [Helm](https://helm.sh/docs/intro/install/)
 

--- a/deployment/console-plugin-nvidia-gpu/templates/consoleplugin.yaml
+++ b/deployment/console-plugin-nvidia-gpu/templates/consoleplugin.yaml
@@ -1,13 +1,16 @@
-apiVersion: console.openshift.io/v1alpha1
+apiVersion: console.openshift.io/v1
 kind: ConsolePlugin
 metadata:
   name: {{ include "console-plugin-nvidia-gpu.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "console-plugin-nvidia-gpu.labels" . | nindent 4 }}
 spec:
   displayName: 'Console Plugin NVIDIA GPU Template'
-  service:
-    name: {{ include "console-plugin-nvidia-gpu.fullname" . }}
-    namespace: {{ .Release.Namespace }}
-    port: 9443
-    basePath: '/'
+  backend:
+    type: Service
+    service:
+      name: {{ include "console-plugin-nvidia-gpu.fullname" . }}
+      namespace: {{ .Release.Namespace }}
+      port: {{ .Values.plugin.port }}
+      basePath: {{ .Values.plugin.basePath }}

--- a/deployment/console-plugin-nvidia-gpu/templates/service.yaml
+++ b/deployment/console-plugin-nvidia-gpu/templates/service.yaml
@@ -1,17 +1,17 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: plugin-serving-cert
   name: {{ include "console-plugin-nvidia-gpu.fullname" . }}
   labels:
     {{- include "console-plugin-nvidia-gpu.labels" . | nindent 4 }}
-  annotations:
-    service.alpha.openshift.io/serving-cert-secret-name: plugin-serving-cert
 spec:
   ports:
-  - name: 9443-tcp
-    protocol: TCP
-    port: 9443
-    targetPort: 9443
+    - name: {{ .Values.plugin.port }}-tcp
+      protocol: TCP
+      port: {{ .Values.plugin.port }}
+      targetPort: {{ .Values.plugin.port }}
   selector:
     {{- include "console-plugin-nvidia-gpu.selectorLabels" . | nindent 4 }}
   type: ClusterIP

--- a/deployment/console-plugin-nvidia-gpu/values.yaml
+++ b/deployment/console-plugin-nvidia-gpu/values.yaml
@@ -27,3 +27,7 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+plugin:
+  port: 9443
+  basePath: /

--- a/deployment/hack/crds/consoleplugin.customresourcedefinition.yaml
+++ b/deployment/hack/crds/consoleplugin.customresourcedefinition.yaml
@@ -13,6 +13,198 @@ spec:
     singular: consoleplugin
   scope: Cluster
   versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "ConsolePlugin is an extension for customizing OpenShift web
+          console by dynamically loading code from another service running on the
+          cluster. \n Compatibility level 1: Stable within a major release for a minimum
+          of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ConsolePluginSpec is the desired plugin configuration.
+            properties:
+              backend:
+                description: backend holds the configuration of backend which is serving
+                  console's plugin .
+                properties:
+                  service:
+                    description: service is a Kubernetes Service that exposes the
+                      plugin using a deployment with an HTTP server. The Service must
+                      use HTTPS and Service serving certificate. The console backend
+                      will proxy the plugins assets from the Service using the service
+                      CA bundle.
+                    properties:
+                      basePath:
+                        default: /
+                        description: basePath is the path to the plugin's assets.
+                          The primary asset it the manifest file called `plugin-manifest.json`,
+                          which is a JSON document that contains metadata about the
+                          plugin and the extensions.
+                        maxLength: 256
+                        minLength: 1
+                        pattern: ^[a-zA-Z0-9.\-_~!$&'()*+,;=:@\/]*$
+                        type: string
+                      name:
+                        description: name of Service that is serving the plugin assets.
+                        maxLength: 128
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: namespace of Service that is serving the plugin
+                          assets.
+                        maxLength: 128
+                        minLength: 1
+                        type: string
+                      port:
+                        description: port on which the Service that is serving the
+                          plugin is listening to.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                    required:
+                    - name
+                    - namespace
+                    - port
+                    type: object
+                  type:
+                    description: "type is the backend type which servers the console's
+                      plugin. Currently only \"Service\" is supported. \n ---"
+                    enum:
+                    - Service
+                    type: string
+                required:
+                - type
+                type: object
+              displayName:
+                description: displayName is the display name of the plugin. The dispalyName
+                  should be between 1 and 128 characters.
+                maxLength: 128
+                minLength: 1
+                type: string
+              i18n:
+                description: i18n is the configuration of plugin's localization resources.
+                properties:
+                  loadType:
+                    description: loadType indicates how the plugin's localization
+                      resource should be loaded. Valid values are Preload, Lazy and
+                      the empty string. When set to Preload, all localization resources
+                      are fetched when the plugin is loaded. When set to Lazy, localization
+                      resources are lazily loaded as and when they are required by
+                      the console. When omitted or set to the empty string, the behaviour
+                      is equivalent to Lazy type.
+                    enum:
+                    - Preload
+                    - Lazy
+                    - ""
+                    type: string
+                required:
+                - loadType
+                type: object
+              proxy:
+                description: proxy is a list of proxies that describe various service
+                  type to which the plugin needs to connect to.
+                items:
+                  description: ConsolePluginProxy holds information on various service
+                    types to which console's backend will proxy the plugin's requests.
+                  properties:
+                    alias:
+                      description: "alias is a proxy name that identifies the plugin's
+                        proxy. An alias name should be unique per plugin. The console
+                        backend exposes following proxy endpoint: \n /api/proxy/plugin/<plugin-name>/<proxy-alias>/<request-path>?<optional-query-parameters>
+                        \n Request example path: \n /api/proxy/plugin/acm/search/pods?namespace=openshift-apiserver"
+                      maxLength: 128
+                      minLength: 1
+                      pattern: ^[A-Za-z0-9-_]+$
+                      type: string
+                    authorization:
+                      default: None
+                      description: authorization provides information about authorization
+                        type, which the proxied request should contain
+                      enum:
+                      - UserToken
+                      - None
+                      type: string
+                    caCertificate:
+                      description: caCertificate provides the cert authority certificate
+                        contents, in case the proxied Service is using custom service
+                        CA. By default, the service CA bundle provided by the service-ca
+                        operator is used.
+                      pattern: ^-----BEGIN CERTIFICATE-----([\s\S]*)-----END CERTIFICATE-----\s?$
+                      type: string
+                    endpoint:
+                      description: endpoint provides information about endpoint to
+                        which the request is proxied to.
+                      properties:
+                        service:
+                          description: 'service is an in-cluster Service that the
+                            plugin will connect to. The Service must use HTTPS. The
+                            console backend exposes an endpoint in order to proxy
+                            communication between the plugin and the Service. Note:
+                            service field is required for now, since currently only
+                            "Service" type is supported.'
+                          properties:
+                            name:
+                              description: name of Service that the plugin needs to
+                                connect to.
+                              maxLength: 128
+                              minLength: 1
+                              type: string
+                            namespace:
+                              description: namespace of Service that the plugin needs
+                                to connect to
+                              maxLength: 128
+                              minLength: 1
+                              type: string
+                            port:
+                              description: port on which the Service that the plugin
+                                needs to connect to is listening on.
+                              format: int32
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                          required:
+                          - name
+                          - namespace
+                          - port
+                          type: object
+                        type:
+                          description: "type is the type of the console plugin's proxy.
+                            Currently only \"Service\" is supported. \n ---"
+                          enum:
+                          - Service
+                          type: string
+                      required:
+                      - type
+                      type: object
+                  required:
+                  - alias
+                  - endpoint
+                  type: object
+                type: array
+            required:
+            - backend
+            - displayName
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
   - name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -160,4 +352,4 @@ spec:
         - spec
         type: object
     served: true
-    storage: true
+    storage: false


### PR DESCRIPTION
The console plugin API has been made GA quite a few OpenShift versions back (in OCP 4.12).
This PR updates the API version to make the plugin work on newer versions of OpenShift, 
makes the port number a variable, and fixes the build.