### PR TITLE
Auto-generate metrics config by merging with upstream

### DIFF
--- a/.github/workflows/helm-lint-test.yaml
+++ b/.github/workflows/helm-lint-test.yaml
@@ -58,6 +58,24 @@ jobs:
           fi
           echo "target_branch=$TARGET_BRANCH" >> $GITHUB_OUTPUT
 
+      - name: Validate metrics file
+        run: |
+          METRICS_FILE="deployment/console-plugin-nvidia-gpu/files/dcgm-metrics.csv"
+          if [ ! -f "$METRICS_FILE" ]; then
+            echo "Error: Metrics file not found at $METRICS_FILE"
+            exit 1
+          fi
+          if [ ! -s "$METRICS_FILE" ]; then
+            echo "Error: Metrics file is empty at $METRICS_FILE"
+            exit 1
+          fi
+          LINE_COUNT=$(wc -l < "$METRICS_FILE")
+          if [ "$LINE_COUNT" -lt 2 ]; then
+            echo "Error: Metrics file must contain at least 2 lines (header + metrics)"
+            exit 1
+          fi
+          echo "Metrics file validation passed: $LINE_COUNT lines"
+
       - name: Run chart-testing (lint)
         if: steps.should-install.outputs.result == 'true'
         run: ct lint --config deployment/ct.yaml --check-version-increment=false --target-branch ${{ steps.should-install.outputs.target_branch }} ${{ github.event.inputs.force_install_unchanged == 'true' && '--all' || '' }}

--- a/.github/workflows/update-metrics.yaml
+++ b/.github/workflows/update-metrics.yaml
@@ -1,0 +1,69 @@
+name: Update DCGM Metrics
+
+on:
+  schedule:
+    - cron: '0 9 1 * *'  # Monthly on the 1st at 9 AM UTC
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  update-metrics:
+    runs-on: ubuntu-latest
+    if: github.repository == 'rh-ecosystem-edge/console-plugin-nvidia-gpu'
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run update-metrics script
+        run: ./scripts/update-metrics.sh
+
+      - name: Check for changes
+        id: check_changes
+        run: |
+          if git diff --quiet deployment/console-plugin-nvidia-gpu/files/dcgm-metrics.csv; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create Pull Request
+        if: steps.check_changes.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Update DCGM metrics from upstream"
+          branch: update-dcgm-metrics
+          delete-branch: true
+          title: "Update DCGM metrics from upstream"
+          body: |
+            This PR updates the DCGM metrics file with the latest metrics from upstream.
+
+            The metrics file is merged from:
+            - `scripts/required-metrics.csv` (metrics required by this plugin)
+            - [Upstream DCGM exporter defaults](https://github.com/NVIDIA/dcgm-exporter/blob/main/etc/dcp-metrics-included.csv)
+
+            This PR was automatically created by the [Update DCGM Metrics workflow](https://github.com/${{ github.repository }}/actions/workflows/update-metrics.yaml).
+
+      - name: Create failure issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          WORKFLOW_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          gh issue create \
+            --repo ${{ github.repository }} \
+            --title "DCGM metrics update workflow failed" \
+            --body "$(cat <<EOF
+          The [Update DCGM Metrics workflow]($WORKFLOW_URL) failed.
+
+          **Workflow run:** $WORKFLOW_URL
+          **Triggered by:** ${{ github.event_name }}
+          **Run date:** $(date -u +"%Y-%m-%d %H:%M:%S UTC")
+
+          Please investigate the failure and fix the issue.
+          EOF
+          )"

--- a/deployment/console-plugin-nvidia-gpu/files/dcgm-metrics.csv
+++ b/deployment/console-plugin-nvidia-gpu/files/dcgm-metrics.csv
@@ -1,0 +1,30 @@
+# This list is auto-generated
+DCGM_FI_PROF_GR_ENGINE_ACTIVE, gauge, Ratio of time the graphics engine is active (gpu utilization).
+DCGM_FI_DEV_MEM_COPY_UTIL, gauge, Memory utilization (in %).
+DCGM_FI_DEV_ENC_UTIL, gauge, Encoder utilization (in %).
+DCGM_FI_DEV_DEC_UTIL, gauge, Decoder utilization (in %).
+DCGM_FI_DEV_POWER_USAGE, gauge, Power draw (in W).
+DCGM_FI_DEV_POWER_MGMT_LIMIT_MAX, gauge, Maximum power management limit (in W).
+DCGM_FI_DEV_GPU_TEMP, gauge, GPU temperature (in C).
+DCGM_FI_DEV_SM_CLOCK, gauge, SM clock frequency (in MHz).
+DCGM_FI_DEV_MAX_SM_CLOCK, gauge, Maximum SM clock frequency (in MHz).
+DCGM_FI_DEV_MEM_CLOCK, gauge, Memory clock frequency (in MHz).
+DCGM_FI_DEV_MAX_MEM_CLOCK, gauge, Maximum memory clock frequency (in MHz).
+DCGM_FI_DEV_MEMORY_TEMP, gauge, Memory temperature (in C).
+DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION, counter, Total energy consumption since boot (in mJ).
+DCGM_FI_DEV_PCIE_REPLAY_COUNTER, counter, Total number of PCIe retries.
+DCGM_FI_DEV_GPU_UTIL,      gauge, GPU utilization (in %).
+DCGM_FI_DEV_XID_ERRORS,            gauge,   Value of the last XID error encountered.
+DCGM_FI_DEV_FB_FREE, gauge, Framebuffer memory free (in MiB).
+DCGM_FI_DEV_FB_USED, gauge, Framebuffer memory used (in MiB).
+DCGM_FI_DEV_FB_RESERVED, gauge, Framebuffer memory reserved (in MiB).
+DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL,            counter, Total number of NVLink bandwidth counters for all lanes.
+DCGM_FI_DEV_VGPU_LICENSE_STATUS, gauge, vGPU License status
+DCGM_FI_DEV_UNCORRECTABLE_REMAPPED_ROWS, counter, Number of remapped rows for uncorrectable errors
+DCGM_FI_DEV_CORRECTABLE_REMAPPED_ROWS,   counter, Number of remapped rows for correctable errors
+DCGM_FI_DEV_ROW_REMAP_FAILURE,           gauge,   Whether remapping of rows has failed
+DCGM_FI_DRIVER_VERSION,        label, Driver Version
+DCGM_FI_PROF_PIPE_TENSOR_ACTIVE, gauge, Ratio of cycles the tensor (HMMA) pipe is active.
+DCGM_FI_PROF_DRAM_ACTIVE,        gauge, Ratio of cycles the device memory interface is active sending or receiving data.
+DCGM_FI_PROF_PCIE_TX_BYTES,      gauge, The rate of data transmitted over the PCIe bus - including both protocol headers and data payloads - in bytes per second.
+DCGM_FI_PROF_PCIE_RX_BYTES,      gauge, The rate of data received over the PCIe bus - including both protocol headers and data payloads - in bytes per second.

--- a/deployment/console-plugin-nvidia-gpu/templates/configmap.yaml
+++ b/deployment/console-plugin-nvidia-gpu/templates/configmap.yaml
@@ -6,14 +6,4 @@ metadata:
     {{- include "console-plugin-nvidia-gpu.labels" . | nindent 4 }}
 data:
   dcgm-metrics.csv: |
-    DCGM_FI_PROF_GR_ENGINE_ACTIVE, gauge, gpu utilization.
-    DCGM_FI_DEV_MEM_COPY_UTIL, gauge, mem utilization.
-    DCGM_FI_DEV_ENC_UTIL, gauge, enc utilization.
-    DCGM_FI_DEV_DEC_UTIL, gauge, dec utilization.
-    DCGM_FI_DEV_POWER_USAGE, gauge, power usage.
-    DCGM_FI_DEV_POWER_MGMT_LIMIT_MAX, gauge, power mgmt limit.
-    DCGM_FI_DEV_GPU_TEMP, gauge, gpu temp.
-    DCGM_FI_DEV_SM_CLOCK, gauge, sm clock.
-    DCGM_FI_DEV_MAX_SM_CLOCK, gauge, max sm clock.
-    DCGM_FI_DEV_MEM_CLOCK, gauge, mem clock.
-    DCGM_FI_DEV_MAX_MEM_CLOCK, gauge, max mem clock.
+{{ .Files.Get "files/dcgm-metrics.csv" | indent 4 }}

--- a/scripts/required-metrics.csv
+++ b/scripts/required-metrics.csv
@@ -1,0 +1,26 @@
+# Required metrics for the NVIDIA GPU console plugin.
+#
+# These metrics are used by the plugin code and MUST be included
+# in the NVIDIA DCGM exporter configuration, even if they are not
+# included by default.
+#
+# Format: DCGM_FIELD, metric_type, description
+
+# Core utilization metrics
+DCGM_FI_PROF_GR_ENGINE_ACTIVE, gauge, Ratio of time the graphics engine is active (gpu utilization).
+DCGM_FI_DEV_MEM_COPY_UTIL, gauge, Memory utilization (in %).
+DCGM_FI_DEV_ENC_UTIL, gauge, Encoder utilization (in %).
+DCGM_FI_DEV_DEC_UTIL, gauge, Decoder utilization (in %).
+
+# Power metrics
+DCGM_FI_DEV_POWER_USAGE, gauge, Power draw (in W).
+DCGM_FI_DEV_POWER_MGMT_LIMIT_MAX, gauge, Maximum power management limit (in W).
+
+# Temperature metrics
+DCGM_FI_DEV_GPU_TEMP, gauge, GPU temperature (in C).
+
+# Clock frequency metrics
+DCGM_FI_DEV_SM_CLOCK, gauge, SM clock frequency (in MHz).
+DCGM_FI_DEV_MAX_SM_CLOCK, gauge, Maximum SM clock frequency (in MHz).
+DCGM_FI_DEV_MEM_CLOCK, gauge, Memory clock frequency (in MHz).
+DCGM_FI_DEV_MAX_MEM_CLOCK, gauge, Maximum memory clock frequency (in MHz).

--- a/scripts/update-metrics.sh
+++ b/scripts/update-metrics.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Merges required metrics with upstream DCGM exporter defaults.
+# This ensures the plugin has all metrics it needs while staying current with upstream.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+UPSTREAM_URL="https://raw.githubusercontent.com/NVIDIA/dcgm-exporter/refs/heads/main/etc/dcp-metrics-included.csv"
+REQUIRED_METRICS_FILE="${SCRIPT_DIR}/required-metrics.csv"
+METRICS_FILE="${REPO_ROOT}/deployment/console-plugin-nvidia-gpu/files/dcgm-metrics.csv"
+TEMP_DIR=$(mktemp -d)
+
+cleanup() {
+    rm -rf "${TEMP_DIR}"
+}
+trap cleanup EXIT
+
+echo "Fetching upstream DCGM metrics..."
+curl -fsSL "${UPSTREAM_URL}" -o "${TEMP_DIR}/upstream-metrics.csv"
+
+echo "Merging ${REQUIRED_METRICS_FILE} with upstream metrics..."
+grep -E '^DCGM_' "${TEMP_DIR}/upstream-metrics.csv" > "${TEMP_DIR}/upstream-parsed.csv" || true
+grep -E '^DCGM_' "${REQUIRED_METRICS_FILE}" > "${TEMP_DIR}/required-parsed.csv" || true
+
+cat > "${METRICS_FILE}" <<'EOF'
+# This list is auto-generated
+EOF
+
+cat "${TEMP_DIR}/required-parsed.csv" "${TEMP_DIR}/upstream-parsed.csv" | \
+    awk 'BEGIN {FS=","; OFS=","} {for(i=1; i<=NF; i++) gsub(/^[[:space:]]+|[[:space:]]+$/, "", $i); if (!seen[$1]++) print}' >> "${METRICS_FILE}"
+
+echo "Updated: ${METRICS_FILE}"


### PR DESCRIPTION
Users of this console plugin are required to replace their current list of DCGM metrics with the list installed by the plugin, because the plugin uses a few metrics that are not included with the DCGM exporter by default.

In order to make this configuration switch less intrusive, and to cover the most likely case when no custom DCGM configuration is used, we want to include the metrics required by this plugin in addition to, and not instead of, the default ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated monthly updates for DCGM metrics with optional manual run.
  * Metrics content now loaded from an external file at render time.

* **Bug Fixes**
  * Validation step added to fail early if the metrics file is missing or invalid.

* **Chores**
  * Added tooling and CI workflow to synchronize and validate metrics automatically.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->