### PR TITLE
Fix container image build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 
 FROM registry.access.redhat.com/ubi8/nodejs-16:latest AS builder
 USER root
-RUN npm install -g corepack
+RUN npm install -g corepack@0.17.0
 RUN corepack enable yarn
 
 COPY . /opt/app-root/src


### PR DESCRIPTION
Pinned package manager tooling to older version compatible with Node.js 16. Recent versions dropped Node.js 16 support, causing builds to fail with missing globalThis.fetch errors. This maintains compatibility with the existing base image without requiring upgrades.