### PR TITLE
Use dynamic target branch in chart-testing workflow

### DIFF
--- a/.github/workflows/helm-lint-test.yaml
+++ b/.github/workflows/helm-lint-test.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: helm/chart-testing-action@v2.2.0
 
       - name: Run chart-testing (lint)
-        run: ct lint --config deployment/ct.yaml --check-version-increment=false
+        run: ct lint --config deployment/ct.yaml --target-branch ${{ github.base_ref }} --check-version-increment=false
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0
@@ -50,4 +50,4 @@ jobs:
           kubectl create -n console-plugin-nvidia-gpu secret tls plugin-serving-cert --key ca.key --cert ca.crt
 
       - name: Run chart-testing (install)
-        run: ct install --namespace console-plugin-nvidia-gpu --config deployment/ct.yaml
+        run: ct install --namespace console-plugin-nvidia-gpu --config deployment/ct.yaml --target-branch ${{ github.base_ref }}

--- a/deployment/ct.yaml
+++ b/deployment/ct.yaml
@@ -1,5 +1,8 @@
 # See https://github.com/helm/chart-testing#configuration
+# Note: target-branch is intentionally not set here to avoid accidentally
+# comparing against the wrong branch. When running locally, specify it explicitly:
+#   ct lint --config deployment/ct.yaml --target-branch <branch-name>
+# In CI, the workflow automatically sets it to the PR base branch.
 remote: origin
-target-branch: main
 chart-dirs:
   - deployment


### PR DESCRIPTION
Set target-branch dynamically from PR base ref instead of hardcoding in ct.yaml. This allows the workflow to work correctly across all branches without manual updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI chart-testing now uses the pull request's base branch for lint and install validation, ensuring checks run against the correct branch.
  * Chart testing config no longer hardcodes a default target branch and includes guidance comments on how to set a branch locally or rely on CI.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->