### PR TITLE
Generate an error on incompatible OpenShift versions

### DIFF
--- a/deployment/console-plugin-nvidia-gpu/README.md
+++ b/deployment/console-plugin-nvidia-gpu/README.md
@@ -26,7 +26,7 @@ $ helm repo update
 $ helm install -n nvidia-gpu-operator console-plugin-nvidia-gpu rh-ecosystem-edge/console-plugin-nvidia-gpu
 
 # view deployed resources
-$ kubectl -n nvidia-gpu-operator get all -l app.kubernetes.io/name=console-plugin-nvidia-gpu
+$ oc -n nvidia-gpu-operator get all -l app.kubernetes.io/name=console-plugin-nvidia-gpu
 
 # check if a plugins field is specified
 $ oc get consoles.operator.openshift.io cluster --output=jsonpath="{.spec.plugins}"

--- a/deployment/console-plugin-nvidia-gpu/templates/NOTES.txt
+++ b/deployment/console-plugin-nvidia-gpu/templates/NOTES.txt
@@ -1,6 +1,6 @@
 View the Console Plugin NVIDIA GPU deployed resources by running the following command:
 
-$ kubectl -n {{ .Release.Namespace }} get all -l app.kubernetes.io/name=console-plugin-nvidia-gpu
+$ oc -n {{ .Release.Namespace }} get all -l app.kubernetes.io/name=console-plugin-nvidia-gpu
 
 Enable the plugin by running the following commands:
 

--- a/deployment/console-plugin-nvidia-gpu/templates/_helpers.tpl
+++ b/deployment/console-plugin-nvidia-gpu/templates/_helpers.tpl
@@ -63,3 +63,18 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+OpenShift version check. Fails if cluster version is below minimum required.
+*/}}
+{{- define "console-plugin-nvidia-gpu.validateOpenShiftVersion" -}}
+{{- $kubeMinor := regexReplaceAll "[^0-9]" .Capabilities.KubeVersion.Minor "" -}}
+{{- $kubeMinorInt := int $kubeMinor -}}
+{{- $minKubeMinor := 32 -}}
+{{- $minOpenShift := "4.19" -}}
+{{- /* Calculate detected OpenShift version: OCP 4.x = K8s 1.(x+13) */ -}}
+{{- $detectedOCP := printf "4.%d" (sub $kubeMinorInt 13) -}}
+{{- if lt $kubeMinorInt $minKubeMinor -}}
+{{- fail (printf "Detected OpenShift %s (Kubernetes 1.%d). This chart requires OpenShift %s (Kubernetes 1.%d) or later. Use chart version 0.2.x for OpenShift 4.18 and earlier." $detectedOCP $kubeMinorInt $minOpenShift $minKubeMinor) -}}
+{{- end -}}
+{{- end -}}

--- a/deployment/console-plugin-nvidia-gpu/templates/deployment.yaml
+++ b/deployment/console-plugin-nvidia-gpu/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "console-plugin-nvidia-gpu.validateOpenShiftVersion" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployment now validates minimum supported OpenShift/Kubernetes version (4.19 or later) and fails with a clear error if requirements are not met.
* **Documentation**
  * Updated user instructions and post-install notes to use oc for viewing deployed resources instead of kubectl.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->