### PR TITLE
Preserve Helm index metadata when publishing releases

### DIFF
--- a/.github/workflows/publish-helm-release.yaml
+++ b/.github/workflows/publish-helm-release.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Update Helm repository index
         working-directory: gh-pages
         run: |
-          helm repo index .
+          helm repo index . --merge index.yaml
 
       - name: Checkout validation script from main
         uses: actions/checkout@v6


### PR DESCRIPTION
Use `--merge` flag to retain deprecated status and created timestamps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Helm release publishing workflow to merge with existing index entries, ensuring existing releases are preserved while adding or updating new ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->