### PR TITLE
Deprecate chart version 0.1.0

### DIFF
--- a/deployment/console-plugin-nvidia-gpu/Chart.yaml
+++ b/deployment/console-plugin-nvidia-gpu/Chart.yaml
@@ -12,6 +12,7 @@ keywords:
   - gpu
 type: application
 version: 0.1.0
+deprecated: true
 maintainers:
   - name: mresvanis
     email: mres@redhat.com


### PR DESCRIPTION
Mark the 0.1.0 release as deprecated in Chart.yaml metadata